### PR TITLE
Add React layer to spacemacs

### DIFF
--- a/.spacemacs
+++ b/.spacemacs
@@ -40,6 +40,7 @@ values."
      yaml
      html
      javascript
+     react
      sql
      ;; ----------------------------------------------------------------
      ;; Example of useful layers you may want to use right away.


### PR DESCRIPTION
# What

Adds the [`react` layer](http://spacemacs.org/layers/+frameworks/react/README.html) to spacemacs.

# Why

Without this, you don't get any syntax highlighting in jsx files. There might be other ways to get that, but this seemed like the easiest. Open to dissenting opinions.